### PR TITLE
Fail over backend DB.

### DIFF
--- a/pgpool/configs/pgpool.conf
+++ b/pgpool/configs/pgpool.conf
@@ -385,7 +385,7 @@ failback_command = ''
                                    #   %R = new master database cluster path
                                    #   %% = '%' character
 
-fail_over_on_backend_error = off
+fail_over_on_backend_error = on
                                    # Initiates failover when reading/writing to the
                                    # backend communication socket fails
                                    # If set to off, pgpool will report an


### PR DESCRIPTION
    If a backend DB container dies, let pgpool fail it over.