### PR TITLE
Non-standard postgres port fix

### DIFF
--- a/src/pgsql/bin/functions/cluster_master
+++ b/src/pgsql/bin/functions/cluster_master
@@ -8,7 +8,7 @@ if [ "$PARTNER_NODES" != "" ]; then
     for NODE in "${NODES[@]}"
     do
         echo ">>>>>> Checking NODE=$NODE..."  >&2
-        MASTER_CONNINFO=`PGCONNECT_TIMEOUT=$CHECK_PGCONNECT_TIMEOUT PGPASSWORD=$REPLICATION_PASSWORD psql -h $NODE -U $REPLICATION_USER $REPLICATION_DB  -tAc "SELECT conninfo FROM $(get_repmgr_schema).$REPMGR_SHOW_NODES_TABLE WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"`
+        MASTER_CONNINFO=`PGCONNECT_TIMEOUT=$CHECK_PGCONNECT_TIMEOUT PGPASSWORD=$REPLICATION_PASSWORD psql -h $NODE -p $REPLICATION_PRIMARY_PORT -U $REPLICATION_USER $REPLICATION_DB  -tAc "SELECT conninfo FROM $(get_repmgr_schema).$REPMGR_SHOW_NODES_TABLE WHERE (upstream_node_name IS NULL OR upstream_node_name = '') AND active=true"`
         if [[ "$?" -ne "0" ]]; then
             echo ">>>>>> Skipping: failed to get master from the node!"  >&2
             continue

--- a/src/pgsql/bin/functions/do_replication
+++ b/src/pgsql/bin/functions/do_replication
@@ -4,5 +4,5 @@ echo ">>> Clonning primary node..."
 echo `date` > $REPLICATION_LOCK_FILE
 
 wait_replication &
-PGPASSWORD=$REPLICATION_PASSWORD gosu postgres repmgr -h $CURRENT_REPLICATION_PRIMARY_HOST -U $REPLICATION_USER -d $REPLICATION_DB -D $PGDATA standby clone --fast-checkpoint --force
+PGPASSWORD=$REPLICATION_PASSWORD gosu postgres repmgr -h $CURRENT_REPLICATION_PRIMARY_HOST -p $REPLICATION_PRIMARY_PORT -U $REPLICATION_USER -d $REPLICATION_DB -D $PGDATA standby clone --fast-checkpoint --force
 rm -rf $REPLICATION_LOCK_FILE


### PR DESCRIPTION
In scripts `cluster_master` and `do_replication`, a non-standard port set through `REPLICATION_PRIMARY_PORT` env var was not passed as an argument, falling back to default port and failing in situations where `REPLICATION_PRIMARY_PORT` is not standard `5432`.