### PR TITLE
fix for example2-single-statefullset volumeMounts configuration

### DIFF
--- a/k8s/example2-single-statefulset/nodes/node.yml
+++ b/k8s/example2-single-statefulset/nodes/node.yml
@@ -98,3 +98,4 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: db-data
+        

--- a/k8s/example2-single-statefulset/nodes/node.yml
+++ b/k8s/example2-single-statefulset/nodes/node.yml
@@ -92,6 +92,9 @@ spec:
                   key: app.db.cluster.replication.password
           ports:
             - containerPort: 5432
+          volumeMounts:
+            - name: db-data
+              mountPath: /var/lib/postgresql/data
   volumeClaimTemplates:
     - metadata:
         name: db-data


### PR DESCRIPTION
I found a problem in example2-single-statefulset. If I restart postgres pods then all data is been lost. I fixed a configuration of StatefulSet by adding volumeMounts to get it work. I prepared a pull request for it. Please review it. 