### PR TITLE
Loading k8s test volume error

### DIFF
--- a/k8s/example2-single-statefulset/volumes/volume-0.yml
+++ b/k8s/example2-single-statefulset/volumes/volume-0.yml
@@ -11,6 +11,7 @@ spec:
   capacity:
     storage: 100Gi
   persistentVolumeReclaimPolicy: Delete
+  storageClassName: standard
   hostPath:
     path: /tmp/db-data-mysystem-db-node-0
   # awsElasticBlockStore:


### PR DESCRIPTION
` Failed to provision volume with StorageClass "standard": claim.Spec.Selector is not supported for dynamic provisioning on GCE`
It wont attach the volume to the pvc unless u specify the storageclass on both pv and pvc