### PR TITLE
Loading k8s test volume error pvc part

### DIFF
--- a/k8s/example2-single-statefulset/volumes/claim-0.yml
+++ b/k8s/example2-single-statefulset/volumes/claim-0.yml
@@ -13,3 +13,4 @@ spec:
     matchLabels:
       system: mysystem-db
       node: node-0
+  storageClassName: standard      


### PR DESCRIPTION
` Failed to provision volume with StorageClass "standard": claim.Spec.Selector is not supported for dynamic provisioning on GCE`
It wont attach the volume to the pvc unless u specify the storageclass on both pv and pvc