### PR TITLE
Create postgres user explicitly if $POSTGRES_USER is not "postgres"

### DIFF
--- a/src/pgsql/bin/postgres/primary/entrypoint.sh
+++ b/src/pgsql/bin/postgres/primary/entrypoint.sh
@@ -2,6 +2,13 @@
 set -e
 FORCE_RECONFIGURE=1 postgres_configure
 
+# We need to create postgres user explicitly,
+# see https://github.com/docker-library/postgres/commit/3f585c58df93e93b730c09a13e8904b96fa20c58
+if [ ! "$POSTGRES_USER" = "postgres" ]; then
+	echo ">>> Creating postgres user explicitly"
+	psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -c "CREATE ROLE postgres LOGIN SUPERUSER"
+fi
+
 echo ">>> Creating replication user '$REPLICATION_USER'"
 psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -c "CREATE ROLE $REPLICATION_USER WITH REPLICATION PASSWORD '$REPLICATION_PASSWORD' SUPERUSER CREATEDB  CREATEROLE INHERIT LOGIN;"
 


### PR DESCRIPTION
This is because initdb in official PostgreSQL Docker image does not
create postgres user during initialization anymore. Therefore createdb
statement which implicitly uses postgres system user to connect to
the cluster will fail.

See https://github.com/docker-library/postgres/commit/3f585c58df93e93b730c09a13e8904b96fa20c58