### PR TITLE
Allow to define SSL keys for configuration and chown then for proper usage

### DIFF
--- a/src/pgsql/bin/postgres/entrypoint.sh
+++ b/src/pgsql/bin/postgres/entrypoint.sh
@@ -46,7 +46,7 @@ fi
 ORIGKEYS=$(egrep '(ssl_cert_file|ssl_key_file)' $PGDATA/postgresql.conf|cut -d "=" -f 2-)
 KEYS=""
 
-for file in ${KEYS}; do
+for file in ${ORIGKEYS}; do
     if [ -f /pg-ssl/$(dirname ${file}) ]; then
         echo ">>> Copying SSL file from /pg-ssl/$(dirname ${file}) to ${file}"
         cat /pg-ssl/$(dirname ${file}) > ${file}

--- a/src/pgsql/bin/postgres/entrypoint.sh
+++ b/src/pgsql/bin/postgres/entrypoint.sh
@@ -42,10 +42,13 @@ else
     fi
 fi
 
+
+echo ">>> Trying to configure SSL"
 # Tweak keys to avoid permission issues:
-ORIGKEYS=$(egrep '(ssl_cert_file|ssl_key_file)' $PGDATA/postgresql.conf|cut -d "=" -f 2-)
+ORIGKEYS=$(echo $CONFIGS|tr "," "\n"|egrep '(ssl_cert_file|ssl_key_file)'|cut -d ":" -f 2-)
 KEYS=""
 
+echo ">>> Trying to move ${ORIGKEYS} to proper folder"
 for file in ${ORIGKEYS}; do
     # Check for file or link pointing to file
     if [ -e /pg-ssl/$(basename ${file}) ]; then

--- a/src/pgsql/bin/postgres/entrypoint.sh
+++ b/src/pgsql/bin/postgres/entrypoint.sh
@@ -45,7 +45,7 @@ fi
 
 echo ">>> Trying to configure SSL"
 # Tweak keys to avoid permission issues:
-ORIGKEYS=$(echo $CONFIGS|tr "," "\n"|egrep '(ssl_cert_file|ssl_key_file)'|cut -d ":" -f 2-|tr "\n" " ")
+ORIGKEYS=$(echo $CONFIGS|tr "," "\n"|egrep '(ssl_cert_file|ssl_key_file)'|cut -d ":" -f 2-|tr "\n" " "|tr -d "\'")
 KEYS=""
 
 echo ">>> Trying to move ${ORIGKEYS} to proper folder"
@@ -56,7 +56,7 @@ for file in ${ORIGKEYS}; do
         mkdir -p $(dirname ${file})
         cat /pg-ssl/$(basename ${file}) > ${file}
         KEYS="$KEYS ${file}"
-    else:
+    else
         echo ">>> ERROR: SSL File ${file} doesn't exist on disk"
     fi
 done

--- a/src/pgsql/bin/postgres/entrypoint.sh
+++ b/src/pgsql/bin/postgres/entrypoint.sh
@@ -42,7 +42,8 @@ else
     fi
 fi
 
-chown -R postgres $PGDATA && chmod -R 0700 $PGDATA
+KEYS=$(egrep '(ssl_cert_file|ssl_key_file)' $PGDATA/postgresql.conf|cut -d "=" -f 2-)
+chown -R postgres $PGDATA $KEYS && chmod -R 0700 $PGDATA $KEYS
 
 source /usr/local/bin/cluster/repmgr/configure.sh
 

--- a/src/pgsql/bin/postgres/entrypoint.sh
+++ b/src/pgsql/bin/postgres/entrypoint.sh
@@ -45,7 +45,7 @@ fi
 
 echo ">>> Trying to configure SSL"
 # Tweak keys to avoid permission issues:
-ORIGKEYS=$(echo $CONFIGS|tr "," "\n"|egrep '(ssl_cert_file|ssl_key_file)'|cut -d ":" -f 2-)
+ORIGKEYS=$(echo $CONFIGS|tr "," "\n"|egrep '(ssl_cert_file|ssl_key_file)'|cut -d ":" -f 2-|tr "\n" " ")
 KEYS=""
 
 echo ">>> Trying to move ${ORIGKEYS} to proper folder"
@@ -56,6 +56,8 @@ for file in ${ORIGKEYS}; do
         mkdir -p $(dirname ${file})
         cat /pg-ssl/$(basename ${file}) > ${file}
         KEYS="$KEYS ${file}"
+    else:
+        echo ">>> ERROR: SSL File ${file} doesn't exist on disk"
     fi
 done
 

--- a/src/pgsql/bin/postgres/entrypoint.sh
+++ b/src/pgsql/bin/postgres/entrypoint.sh
@@ -42,7 +42,18 @@ else
     fi
 fi
 
-KEYS=$(egrep '(ssl_cert_file|ssl_key_file)' $PGDATA/postgresql.conf|cut -d "=" -f 2-)
+# Tweak keys to avoid permission issues:
+ORIGKEYS=$(egrep '(ssl_cert_file|ssl_key_file)' $PGDATA/postgresql.conf|cut -d "=" -f 2-)
+KEYS=""
+
+for file in ${KEYS}; do
+    if [ -f /pg-ssl/$(dirname ${file}) ]; then
+        echo ">>> Copying SSL file from /pg-ssl/$(dirname ${file}) to ${file}"
+        cat /pg-ssl/$(dirname ${file}) > ${file}
+        KEYS="$KEYS ${file}"
+    fi
+done
+
 chown -R postgres $PGDATA $KEYS && chmod -R 0700 $PGDATA $KEYS
 
 source /usr/local/bin/cluster/repmgr/configure.sh

--- a/src/pgsql/bin/postgres/entrypoint.sh
+++ b/src/pgsql/bin/postgres/entrypoint.sh
@@ -47,9 +47,10 @@ ORIGKEYS=$(egrep '(ssl_cert_file|ssl_key_file)' $PGDATA/postgresql.conf|cut -d "
 KEYS=""
 
 for file in ${ORIGKEYS}; do
-    if [ -f /pg-ssl/$(dirname ${file}) ]; then
-        echo ">>> Copying SSL file from /pg-ssl/$(dirname ${file}) to ${file}"
-        cat /pg-ssl/$(dirname ${file}) > ${file}
+    if [ -f /pg-ssl/$(basename ${file}) ]; then
+        echo ">>> Copying SSL file from /pg-ssl/$(basename ${file}) to ${file}"
+        mkdir -p $(dirname ${file})
+        cat /pg-ssl/$(basename ${file}) > ${file}
         KEYS="$KEYS ${file}"
     fi
 done

--- a/src/pgsql/bin/repmgr/configure.sh
+++ b/src/pgsql/bin/repmgr/configure.sh
@@ -17,7 +17,7 @@ pg_bindir=/usr/lib/postgresql/$PG_MAJOR/bin
 
 $REPMGR_NODE_ID_PARAM_NAME=$(get_node_id)
 node_name=$NODE_NAME
-conninfo='user=$REPLICATION_USER password=$REPLICATION_PASSWORD host=$CLUSTER_NODE_NETWORK_NAME dbname=$REPLICATION_DB port=5432 connect_timeout=$CONNECT_TIMEOUT'
+conninfo='user=$REPLICATION_USER password=$REPLICATION_PASSWORD host=$CLUSTER_NODE_NETWORK_NAME dbname=$REPLICATION_DB port=$REPLICATION_PRIMARY_PORT connect_timeout=$CONNECT_TIMEOUT'
 failover=automatic
 promote_command='PGPASSWORD=$REPLICATION_PASSWORD repmgr standby promote --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=$REPLICATION_PASSWORD repmgr standby follow -W --log-level DEBUG --verbose'

--- a/src/pgsql/bin/repmgr/configure.sh
+++ b/src/pgsql/bin/repmgr/configure.sh
@@ -17,7 +17,7 @@ pg_bindir=/usr/lib/postgresql/$PG_MAJOR/bin
 
 $REPMGR_NODE_ID_PARAM_NAME=$(get_node_id)
 node_name=$NODE_NAME
-conninfo='user=$REPLICATION_USER password=$REPLICATION_PASSWORD host=$CLUSTER_NODE_NETWORK_NAME dbname=$REPLICATION_DB port=$REPLICATION_PRIMARY_PORT connect_timeout=$CONNECT_TIMEOUT'
+conninfo='user=$REPLICATION_USER password=$REPLICATION_PASSWORD host=$CLUSTER_NODE_NETWORK_NAME dbname=$REPLICATION_DB port=5432 connect_timeout=$CONNECT_TIMEOUT'
 failover=automatic
 promote_command='PGPASSWORD=$REPLICATION_PASSWORD repmgr standby promote --log-level DEBUG --verbose'
 follow_command='PGPASSWORD=$REPLICATION_PASSWORD repmgr standby follow -W --log-level DEBUG --verbose'


### PR DESCRIPTION
Allow to define ssl settings via environment variable and check them on /pg-ssl secret in kubernetes so that keys are copied and chowned to end folder:

CONFIGS: ssl:on,ssl_cert_file:'/etc/postgresql/server.crt',ssl_key_file:'/etc/postgresql/server.key'
And provide a secret like:

apiVersion: v1
data:
  server.crt: >-
    YOURSECRET
  server.key: >-
    YOURSECRET
kind: Secret
metadata:
  name: postgres
  namespace: YOURNAMESPACE
  selfLink: /api/v1/namespaces/quay-enterprise/secrets/postgres
type: Opaque
That must be mounted on /pg-ssl