### PR TITLE
Update do_rewind

### DIFF
--- a/src/pgsql/bin/functions/do_rewind
+++ b/src/pgsql/bin/functions/do_rewind
@@ -10,7 +10,7 @@ if [[ "$MASTER_SLAVE_SWITCH" == "1" ]] || [ "$TRY_TO_FOLLOW_CLUSTER_MASTER" == "
     gosu postgres repmgr standby archive-config --config-archive-dir=/tmp/repmgr-archive
 
     echo ">>>>>> Start server to be able to rewind (weird hack to avoid dirty shutdown issue)"
-    rm -rf $PGDATA/pg_xlog/archive_status/
+    rm -rf $PGDATA/pg_wal/archive_status/
     rm $PGDATA/postmaster.pid
     gosu postgres pg_ctl -D "$PGDATA"  -o "-c listen_addresses='localhost'" -w start 
 


### PR DESCRIPTION
A later version of PostgreSQL uses pg_wal instead of pg_xlog. This fixes master failed when restarting.