### PR TITLE
Start Pgpool with tini

### DIFF
--- a/src/barman/bin/wal-receiver.sh
+++ b/src/barman/bin/wal-receiver.sh
@@ -5,7 +5,7 @@ SLOTS_COUNT=`barman show-server $UPSTREAM_NAME | grep "replication_slot: Record(
 if [ "$SLOTS_COUNT" -gt "0" ]; then 
 	echo "Looks like replication slot already exists"
 else 
-	echo "Creating replication slot: $REPLICATION_SLOT_NAM"
+	echo "Creating replication slot: $REPLICATION_SLOT_NAME"
 	barman receive-wal --create-slot $UPSTREAM_NAME
 fi
 

--- a/src/includes/dockerfile/Pgpool-3.3-3.7.part.Dockerfile
+++ b/src/includes/dockerfile/Pgpool-3.3-3.7.part.Dockerfile
@@ -39,6 +39,12 @@ COPY ./pgpool/configs /var/pgpool_configs
 
 RUN chmod +x -R /usr/local/bin/pgpool
 
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
+RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+	&& gpg --verify /tini.asc && chmod a+x /tini
+
 ENV CHECK_USER replication_user
 ENV CHECK_PASSWORD replication_pass
 ENV CHECK_PGCONNECT_TIMEOUT 10
@@ -60,4 +66,4 @@ EXPOSE 9898
 HEALTHCHECK --interval=1m --timeout=10s --retries=5 \
   CMD /usr/local/bin/pgpool/has_write_node.sh
 
-CMD ["/usr/local/bin/pgpool/entrypoint.sh"]
+CMD ["/tini", "--", "/usr/local/bin/pgpool/entrypoint.sh"]


### PR DESCRIPTION
As described [here](https://github.com/krallin/tini) tiny is a valid `init` for containers.
In our test environment we came across a situation where pgpool along with the pool processes turned into zombies for unknown reasons.  Unfortunately were were not able to reproduce it yet.
However since the entrypoint spins up many process it occurs that `tini` can be a good start for reaping zombies process.