### PR TITLE
Fix Address already in use when restart Docker

### DIFF
--- a/src/pgpool/bin/entrypoint.sh
+++ b/src/pgpool/bin/entrypoint.sh
@@ -6,6 +6,8 @@ export PCP_FILE='/usr/local/etc/pcp.conf'
 export HBA_FILE='/usr/local/etc/pool_hba.conf'
 export POOL_PASSWD_FILE='/usr/local/etc/pool_passwd'
 
+echo '>>> CLEANING environment (if required)...'
+rm -f /var/run/postgresql/.s.PGSQL*
 
 echo '>>> STARTING SSH (if required)...'
 sshd_start


### PR DESCRIPTION
Before start clean sockets files that prevent restart of pgPool and generate error like this:

**FATAL:  failed to bind a socket: "/var/run/postgresql/.s.PGSQL.5432"
DETAIL:  bind socket failed with error: "Address already in use"**