### PR TITLE
fix: for k8s set PGDATA to subfolder

### DIFF
--- a/k8s/example2-single-statefulset/nodes/node.yml
+++ b/k8s/example2-single-statefulset/nodes/node.yml
@@ -96,7 +96,7 @@ spec:
             - containerPort: 5432
           volumeMounts:
             - name: db-data
-              mountPath: /var/lib/postgresql/data/pgdata
+              mountPath: /var/lib/postgresql/data
   volumeClaimTemplates:
     - metadata:
         name: db-data

--- a/k8s/example2-single-statefulset/nodes/node.yml
+++ b/k8s/example2-single-statefulset/nodes/node.yml
@@ -68,6 +68,8 @@ spec:
                 secretKeyRef:
                   name: mysystem-secret
                   key: app.db.password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
 
             # Cluster configs
             - name: "CLUSTER_NAME"
@@ -94,7 +96,7 @@ spec:
             - containerPort: 5432
           volumeMounts:
             - name: db-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql/data/pgdata
   volumeClaimTemplates:
     - metadata:
         name: db-data

--- a/k8s/helm/PostDock/templates/postgres/statefulset.yaml
+++ b/k8s/helm/PostDock/templates/postgres/statefulset.yaml
@@ -90,7 +90,7 @@ spec:
             - containerPort: 5432
           volumeMounts:
             - name: db-data
-              mountPath: /var/lib/postgresql/data/pgdata
+              mountPath: /var/lib/postgresql/data
   volumeClaimTemplates:
     - metadata:
         name: db-data

--- a/k8s/helm/PostDock/templates/postgres/statefulset.yaml
+++ b/k8s/helm/PostDock/templates/postgres/statefulset.yaml
@@ -64,6 +64,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.postDock.name }}-secret
                   key: app.db.password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
             - name: "CLUSTER_NAME"
               valueFrom:
                 configMapKeyRef:
@@ -88,7 +90,7 @@ spec:
             - containerPort: 5432
           volumeMounts:
             - name: db-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql/data/pgdata
   volumeClaimTemplates:
     - metadata:
         name: db-data


### PR DESCRIPTION
> PGDATA
This optional variable can be used to define another location - like a subdirectory - for the database files. The default is /var/lib/postgresql/data, but if the data volume you're using is a filesystem mountpoint (like with GCE persistent disks), Postgres initdb recommends a subdirectory (for example /var/lib/postgresql/data/pgdata ) be created to contain the data.

Source: https://hub.docker.com/_/postgres/

Since within Kubernetes the persistent disks are filesystem mountpoints the PGDATA variable should be set to a subdir.

This should fix #251 but I have not been able to test it yet.

EDIT:
Just tested this and it works fine but it also works fine without (this is on NFS however so might not be completely representable). @Telokis could you test this?
I am still in favor of merging this since it is advised by Postgres 👍 